### PR TITLE
Make carrier waypoints brighter on nav screens

### DIFF
--- a/screen_navigation.lua
+++ b/screen_navigation.lua
@@ -12,7 +12,7 @@ g_is_island_team_colors = true
 g_is_island_names = true
 g_is_deploy_carrier_triggered = false
 g_dock_state_prev = nil
-g_color_waypoint = color8(0, 255, 255, 8)
+g_color_waypoint = color8(127, 255, 255, 127)
 
 
 function parse()


### PR DESCRIPTION
I found they were easy to get lost in the terrain overlays with the current colour (e.g. ocean depth)  So I made them more grey and brighter so they show up better.

before (in depth mode):
![nav_screenorig](https://user-images.githubusercontent.com/569403/130137204-cfc2435d-540b-4ab0-aa8c-5578b6c66a74.png)

after (in depth mode)
![nav_screennew](https://user-images.githubusercontent.com/569403/130137213-a94e9ca8-e505-43c2-a599-bc4246b89d62.png)

And to give an idea of how it looks on other overlays:

cartographic:
![nav_screen_cart](https://user-images.githubusercontent.com/569403/130137281-b7fd90a8-fe06-48fe-8b37-ea6f79a525b4.png)

current:
![nav_screen_curr](https://user-images.githubusercontent.com/569403/130137309-6ce8764d-49db-4a7c-84c7-669e9eb01492.png)

wind:
![nav_screen_wind](https://user-images.githubusercontent.com/569403/130137339-abb06aa0-41be-4a4c-b625-d5c4e252151a.png)

The other overlays didn't show anything in the area of my carrier so I didn't bother to grab those.
