### PR TITLE
Add shell drop indicator to heavy cannon

### DIFF
--- a/vehicle_hud.lua
+++ b/vehicle_hud.lua
@@ -1422,6 +1422,38 @@ function render_attachment_hud_cannon(screen_w, screen_h, map_data, vehicle, att
                 end
             end
         end
+		
+	if def == e_game_object_type.attachment_turret_heavy_cannon and display_zoom > 1 then
+            local projectile_gravity = 50 / 30
+            local projectile_speed = 600
+            local projectile_velocity = update_get_camera_forward()
+            projectile_velocity:x(projectile_velocity:x() * projectile_speed)
+            projectile_velocity:y(projectile_velocity:y() * projectile_speed)
+            projectile_velocity:z(projectile_velocity:z() * projectile_speed)
+
+            local step_amounts = { 800, 400, 200, 100 }
+            local step = step_amounts[math.floor(zoom_power) + 1]
+
+            for i = step, 1600, step do
+                if i > 0 then
+                    local travel_time = math.max(1, i) / (projectile_speed / 30)
+                    local drop_position = update_get_camera_position()
+                    drop_position:x(drop_position:x() + projectile_velocity:x() * travel_time)
+                    drop_position:y(drop_position:y() + projectile_velocity:y() * travel_time - 0.5 * projectile_gravity * travel_time * travel_time)
+                    drop_position:z(drop_position:z() + projectile_velocity:z() * travel_time)
+
+                    local screen_pos = update_world_to_screen(drop_position)
+
+                    if screen_pos:y() < hud_pos:y() + 60 then
+                        update_ui_line(screen_w / 2 - 3, screen_pos:y(), screen_w / 2 + 2, screen_pos:y(), color8(0, 255, 0, 255))
+
+                        if (i / step) % 2 == 0 then
+                            update_ui_text(screen_w / 2 + 4, screen_pos:y() - 5, string.format("%d", i) .. update_get_loc(e_loc.acronym_meters), 64, 0, color8(0, 255, 0, 255), 0)
+                        end
+                    end
+                end
+            end
+        end
     end
 
     return false


### PR DESCRIPTION
Added shell drop indicators to heavy cannon similar to the battle cannon.

They use the same velocity values as the battle cannon, since I cannot find any values specific for the heavy cannon, but out to 1600m.
I tested these out in a limited fashion in-game and so far they seem to be close enough to where the shells are landing.