### PR TITLE
Air Operations Screen mod

### DIFF
--- a/screen_landing.lua
+++ b/screen_landing.lua
@@ -46,15 +46,32 @@ function update(screen_w, screen_h, ticks)
         render_landing_pattern()
 
         local this_vehicle = update_get_screen_vehicle()
-        local docking_vehicles = {}
-
+        --local docking_vehicles = {}
+        
+        local all_air_ops_vehicles = {}
+        
+        --TODO: maybe refactor this entire block down to the list block, why iterate twice?
         if this_vehicle:get() then
-            docking_vehicles = get_docking_vehicles(this_vehicle)
+            --docking_vehicles = get_docking_vehicles(this_vehicle)
+            
+            all_air_ops_vehicles = get_all_air_ops_vehicles(this_vehicle)
 
-            for _, v in pairs(docking_vehicles) do
-                if v.is_wing then
+            for _, v in pairs(all_air_ops_vehicles) do
+            
+                --prevents the drones that are not in the holding or landing pattern to show up on the left side of the screen
+                local render_on_holding = false
+                local vehicle = v.vehicle
+                local vehicle_dock_state = vehicle:get_dock_state()
+                
+                if vehicle_dock_state == e_vehicle_dock_state.dock_queue or vehicle_dock_state == e_vehicle_dock_state.docking then
+                    render_on_holding = true
+                end
+                
+                if v.is_wing and render_on_holding then
                     render_docking_vehicle_wing(this_vehicle, v.vehicle)
-                elseif v.is_rotor then
+                elseif v.is_rotor and render_on_holding then
+                    
+                    -- if you refactor this block into the list block, might as well pass the correct landing state or color through this call because proper landing checks are in the modded list block
                     render_docking_vehicle_rotor(this_vehicle, v.vehicle)
                 end
             end
@@ -67,29 +84,210 @@ function update(screen_w, screen_h, ticks)
         local win_list = ui:begin_window("##list", left_w, 0, right_w, region_h, nil, true, 1, update_get_is_focus_local())
             local list_region_w, list_region_h = ui:get_region()
             
-            local column_widths = { 20, 65, -1 }
-            local column_margins = { 2, 2, 2 }
+            local column_widths = { 30, 25, 20, 20, -1 }
+            local column_margins = { 4, 4, 4, 4, 4 }
 
             imgui_table_header(ui, {
-                { w=column_widths[1], margin=column_margins[1], value=update_get_loc(e_loc.upp_id) },
-                { w=column_widths[2], margin=column_margins[2], value=update_get_loc(e_loc.upp_acronym_vehicle_name_handle) },
+                { w=column_widths[1], margin=column_margins[1], value=atlas_icons.column_transit },
+                { w=column_widths[2], margin=column_margins[2], value=atlas_icons.column_stock },
                 { w=column_widths[3], margin=column_margins[3], value=atlas_icons.column_fuel },
+                { w=column_widths[4], margin=column_margins[4], value=atlas_icons.column_repair },
+                { w=column_widths[5], margin=column_margins[5], value=atlas_icons.column_controlling_peer },
             })
 
             g_hovered_vehicle_id = 0
 
-            if #docking_vehicles > 0 then
-                for _, v in pairs(docking_vehicles) do
+            if #all_air_ops_vehicles > 0 then
+                for _, v in pairs(all_air_ops_vehicles) do
                     local vehicle = v.vehicle
                     local id = vehicle:get_id()
+                    
+                    -- fuel tab
                     local fuel_factor = vehicle:get_fuel_factor()
-                    local vehicle_name = get_chassis_data_by_definition_index(vehicle:get_definition_index())
-                    local fuel_col = iff(fuel_factor < 0.25, color_status_bad, iff(fuel_factor < 0.5, color_status_warning, color_status_ok))
-
+                    local fuel_col = iff(fuel_factor < 0.25, color_status_bad, iff(fuel_factor < 0.5, color_status_warning, color_white))
+                    
+                    local fuel_string = string.format("%.0f", fuel_factor * 100)
+                    
+                    if fuel_factor > 0.99 then
+                        fuel_string = "OK"
+                        fuel_col = color_status_dark_green
+                    end
+                    
+                    -- damage tab
+                    local damage_factor = clamp(vehicle:get_hitpoints() / vehicle:get_total_hitpoints(), 0, 1)
+                    local damage_color = color_white
+                    
+                    local damage_string = "   "
+                    
+                    if damage_factor < 1 then
+                        damage_string = string.format("%.0f", damage_factor * 100)
+                        damage_color = color_status_warning
+                        if damage_factor <= 0.5 then
+                            damage_color = color_status_bad
+                        end
+                    end
+                    
+                    -- drone name tab, this has to be after fuel and damage because it takes those into account
+                    local full_name, vehicle_icon, vehicle_handle = get_chassis_data_by_definition_index(vehicle:get_definition_index())
+                    local name_color = color_white
+                    
+                    if damage_color == color_status_warning or fuel_col == color_status_warning then
+                        name_color = color_status_warning
+                    end
+                    
+                    if damage_color == color_status_bad or fuel_col == color_status_bad then
+                        name_color = color_status_bad
+                    end
+                    
+                    -- drone mode tab, first gets the needed stats from the drone
+                    local vehicle_dock_state = vehicle:get_dock_state()
+                        
+                    local damage_indicator_factor = vehicle:get_damage_indicator_factor()
+                    
+                    local attack_target_type = vehicle:get_attack_target_type()
+                    
+                    local waypoint_count = vehicle:get_waypoint_count()
+                    
+                    local vehicle_manual_flight_control = false
+                    local attachment_control_camera = vehicle:get_attachment(0)
+        
+                    if attachment_control_camera:get() then
+                        if attachment_control_camera:get_definition_index() == e_game_object_type.attachment_camera_vehicle_control then
+                            
+                             --we don't have to worry about the "override" control mode during landing because the landing check takes priority to the human pilot check
+                            if attachment_control_camera:get_control_mode() ~= "auto" then
+                            
+                                vehicle_manual_flight_control = true
+                            end
+                        
+                        else -- normally the flight control module sits in slot 0, but just in case it doesn't for some reason here is a fallback
+                            for a = 1, vehicle:get_attachment_count() , 1 do
+                                attachment_control_camera = vehicle:get_attachment(a)
+                                if attachment_control_camera:get() then
+                                    if attachment_control_camera:get_definition_index() == e_game_object_type.attachment_camera_vehicle_control then
+                                        if attachment_control_camera:get_control_mode() ~= "auto" then
+                                            vehicle_manual_flight_control = true
+                                            break
+                                        end
+                                    end
+                                end
+                            end
+                        end
+                    end
+                    
+                    -- drone mode tab, set the list entry string and color
+                    local vehicle_state_string = "???"
+                    local vehicle_state_color = color_white
+                    
+                    --TODO: incoming damage alert mode, this status is quite short lived, maybe replace it with something else
+                    if damage_indicator_factor > 0 then
+                    
+                        vehicle_state_string = "DMG!"
+                        vehicle_state_color = color_status_bad
+                    
+                    --TODO: plane landing mode. helis don't get the "docking" aka landing state even though the final approach is not cancelable
+                    elseif vehicle_dock_state == e_vehicle_dock_state.docking then
+                    
+                        vehicle_state_string = "LAND"
+                        vehicle_state_color = g_colors.docking
+                        
+                        if vehicle:get_attached_parent_id() ~= 0 then
+                            vehicle_state_string = "PARK"
+                            vehicle_state_color = color_status_dark_red
+                        end
+                    
+                    -- holding mode and helicopter landing mode
+                    elseif vehicle_dock_state == e_vehicle_dock_state.dock_queue then
+                        
+                        vehicle_state_string = "HOLD"
+                        vehicle_state_color = g_colors.dock_queue
+                        
+                        --TODO: had to add the landing check for helis here, because they are in the dock_queue state all the way down to the runway. this basically checks if the heli is inside a 3D box behind the carrier's runway
+                        if v.is_rotor then
+                        
+                            local vehicle_parent = update_get_screen_vehicle()
+                            local relative_position = update_get_map_vehicle_position_relate_to_parent_vehicle(vehicle_parent:get_id(), vehicle:get_id())
+                            local relative_position_z = relative_position:z()
+                            local relative_position_x = relative_position:x()
+                            local relative_position_y = relative_position:y()
+                            
+                            --TODO: rough 3D box size of the heli landing slope
+                            if relative_position_z > -230 and relative_position_z < 20 and relative_position_x > -100 and relative_position_x < 15 and relative_position_y < 150 then
+                                vehicle_state_string = "LAND"
+                                vehicle_state_color = g_colors.docking
+                            end
+                        end
+                    
+                    --TODO: launch mode. "undocking" is also active when the drone is on the crane and going up on the elevator, maybe add a "TAXI" state that is set while the drone is on them? couldn't find a way to check for that though
+                    elseif vehicle_dock_state == e_vehicle_dock_state.undocking then
+                    
+                        vehicle_state_string = "LNCH"
+                        vehicle_state_color = color_status_dark_green
+                    
+                    -- standby mode, "pending_undock" is active when the drone is rearming and refueling, or waiting inside the drone bay for the crane and elevator to be free
+                    elseif vehicle_dock_state == e_vehicle_dock_state.pending_undock then
+                    
+                        vehicle_state_string = "STBY"
+                        vehicle_state_color = g_colors.carrier
+                    
+                    -- manual flight control mode
+                    elseif vehicle_manual_flight_control then
+                    
+                        vehicle_state_string = "HPLT"
+                        vehicle_state_color = color_grey_dark
+                    
+                    -- attack mode, the Petrel's airlift order is a type of attack, make sure to filter it
+                    elseif attack_target_type ~= e_attack_type.none and attack_target_type ~= e_attack_type.airlift then
+                    
+                        vehicle_state_string = "ATTK"
+                        vehicle_state_color = color_status_warning
+                    
+                    -- waypoint modes
+                    elseif waypoint_count > 0 then
+                    
+                        vehicle_state_string = "WYPT"
+                        vehicle_state_color = color_friendly
+                        
+                        --iterate through the waypoints and see if they loop on themselves
+                        for w = 0, waypoint_count - 1, 1 do
+                        
+                            local waypoint = vehicle:get_waypoint(w)
+                            
+                            if waypoint:get_repeat_index(w) >= 0 then
+                            
+                                vehicle_state_string = "LOOP"
+                                vehicle_state_color = color8(0, 30, 230, 255)
+                                break
+                            end
+                        end
+                    
+                    -- free and hover modes
+                    elseif waypoint_count <= 0 then
+                        
+                        -- drone behavior depends on drone type here. planes fly straight ahead, helis hover stationary
+                        if v.is_wing then
+                            vehicle_state_string = "FREE"
+                        elseif v.is_rotor then
+                            vehicle_state_string = "HOVR"
+                        end
+                    end
+                    
+                    -- remote control tab
+                    local controlling_peer_string = " "
+                    
+                    if vehicle:get_controlling_peer_id() ~= 0 then
+                        controlling_peer_string = atlas_icons.column_controlling_peer
+                    end
+                    
+                    -- insert entry into table
                     imgui_table_entry(ui, {
-                        { w=column_widths[1], margin=column_margins[1], value=tostring(id) },
-                        { w=column_widths[2], margin=column_margins[2], value=vehicle_name },
-                        { w=column_widths[3], margin=column_margins[3], value=string.format("%.0f%%", fuel_factor * 100), col=fuel_col },
+
+                        { w=column_widths[1], margin=column_margins[1], value= vehicle_state_string, col= vehicle_state_color },
+                        { w=column_widths[2], margin=column_margins[2], value= vehicle_handle, col= name_color },
+                        { w=column_widths[3], margin=column_margins[3], value= fuel_string, col= fuel_col },
+                        { w=column_widths[4], margin=column_margins[4], value= damage_string, col= damage_color },
+                        { w=column_widths[5], margin=column_margins[5], value= controlling_peer_string, col= color_friendly },
+                        
                     }, false)
 
                     if ui:is_item_selected() and update_get_is_focus_local() then
@@ -202,6 +400,8 @@ function render_docking_vehicle_wing(vehicle_parent, vehicle)
     update_ui_image(p0x - 3, p0z - 3, atlas_icons.map_icon_air, col, 0)
 end
 
+--TODO: this is the unchanged vanilla icon render function for helis on the holding pattern, it has two bugs at the moment, maybe fix this or just remove the pattern render for more drone-list-entry space
+-- 1) its relative range checks are not properly done at the moment so the icon will render at the wrong place or too early sometimes
 function render_docking_vehicle_rotor(vehicle_parent, vehicle)
     local final_arc = g_landing_pattern.final_arc
     local vehicle_dock_state = vehicle:get_dock_state()
@@ -211,6 +411,8 @@ function render_docking_vehicle_rotor(vehicle_parent, vehicle)
     local p0z = -final_arc + math.min(p0x - 10, final_arc)
     
     if relative_position:z() < -120 then
+    
+        -- 2) the docking color is never set because helis skip the "docking" aka landing state and stay in "dock_queue" all the way down to the runway
         local col = iff(vehicle_dock_state == e_vehicle_dock_state.dock_queue, g_colors.dock_queue, g_colors.docking)
 
         if g_hovered_vehicle_id == vehicle:get_id() then
@@ -228,29 +430,32 @@ end
 --
 --------------------------------------------------------------------------------
 
-function get_docking_vehicles(vehicle_parent)
-    local docking_vehicles = {}
+--TODO: modded func of the Air Operations screen
+function get_all_air_ops_vehicles(vehicle_parent)
+    local all_air_ops_vehicles = {}
 
     local vehicle_count = update_get_map_vehicle_count()
+    local screen_team = update_get_screen_team_id()
     
     for i = 0, vehicle_count - 1, 1 do 
         local vehicle = update_get_map_vehicle_by_index(i)
 
         if vehicle:get() then
-            local vehicle_dock_state = vehicle:get_dock_state()
-
-            if vehicle_dock_state == e_vehicle_dock_state.docking or vehicle_dock_state == e_vehicle_dock_state.dock_queue then
-                local vehicle_dock_parent_id = vehicle:get_dock_parent_id()
-
-                if vehicle_dock_parent_id == vehicle_parent:get_id() then
+            if vehicle:get_team() == screen_team then
+                
+                if vehicle:get_dock_state() ~= e_vehicle_dock_state.docked then
+                
                     if vehicle:get_definition_index() == e_game_object_type.chassis_air_wing_light or vehicle:get_definition_index() == e_game_object_type.chassis_air_wing_heavy then
-                        table.insert(docking_vehicles, { 
+                            
+                        table.insert(all_air_ops_vehicles, { 
                             vehicle = vehicle,  
                             is_wing = true,
                             is_rotor = false
                         })
+                            
                     elseif vehicle:get_definition_index() == e_game_object_type.chassis_air_rotor_light or vehicle:get_definition_index() == e_game_object_type.chassis_air_rotor_heavy then
-                        table.insert(docking_vehicles, {
+                        
+                        table.insert(all_air_ops_vehicles, {
                             vehicle = vehicle,
                             is_wing = false,
                             is_rotor = true
@@ -261,7 +466,7 @@ function get_docking_vehicles(vehicle_parent)
         end
     end
 
-    return docking_vehicles
+    return all_air_ops_vehicles
 end
 
 function arc_position(x, y, radius, angle)


### PR DESCRIPTION
Heyo! Originally I was going to release this as a stand-alone mod, but as your mod is the de facto go-to and cooperation and maintenance seem to go well, I figured you might take a look and see if is an addition to your mod you might like, so here is the ReadMe I had prepared:

***Air Operations Screen mod***

This small quality-of-life mod changes the Landing Queue Screen to a more useful Air Operations Screen.
It will show ALL deployed and active air drones, their current tasks, their type, their health and fuel status.
It uses color coding for quick and easy glances from other stations.
This is especially useful for singleplayer but also useful in multiplayer.
This mod does not change the drone AI or handling and is merely cosmetic, and is entirely client-side.

![001](https://user-images.githubusercontent.com/62019824/130309800-043e7c22-c64b-4f66-82f4-563ac37d47f0.jpg)
![002](https://user-images.githubusercontent.com/62019824/130309897-b379d4a5-c1d7-46b6-b063-d948bbd98d88.jpg)
![003](https://user-images.githubusercontent.com/62019824/130309900-addd9521-603d-44b1-acc4-2b76de003ece.jpg)
![004](https://user-images.githubusercontent.com/62019824/130309910-499d74e8-cd20-4b0c-a32b-ae80be177b88.jpg)
![011](https://user-images.githubusercontent.com/62019824/130309930-34189087-79e9-4962-b94b-41a058efb2aa.jpg)
![009](https://user-images.githubusercontent.com/62019824/130309935-ee895a26-28ab-4ebd-bd2f-db035ec17860.jpg)
![014](https://user-images.githubusercontent.com/62019824/130309949-77fc280f-8ac3-487d-bd9d-3c6deaf57d71.jpg)
![015](https://user-images.githubusercontent.com/62019824/130309961-09bed9b4-1493-4232-ad0f-ca234a3e5b54.jpg)


***HOW TO READ THE SCREEN:***

_**1) The status tab of the modded ATC screen has several status modes for air drones, modes further up will take priority over modes below:**_

"DMG!" = Damage!     = Drone is actively being damaged! Beware that this mode only shows briefly, so make sure to check the health percentage on the screen too.

"PARK" = Parking     = Drone is parking after a landing. It is on the runway, or moving down the elevator, or being brought to its drone bay by the crane.

"LAND" = Landing     = Drone is in the final landing phase. Landing can not be aborted anymore.

"HOLD" = Holding     = Drone is inside or on its way to the holding pattern preparing for landing. Landing can still be aborted.

"LNCH" = Launch	     = Drone is in the launching phase. It is on the runway, or moving up the elevator, or being brought to the elevator by the crane. Launch can not be aborted anymore.

"STBY" = Standby     = Drone is standing by for launch, it is being refueld and rearmed, or waiting for the crane and elevator to be free. Launch can still be aborted.

"HPLT" = Human Pilot = Drone is piloted manually by a human player from a drone control terminal. This only checks the actual flight controls, not if the gimbal camera, weapons and other attachments are in human control, check the remote control tab for those.

"ATTK" = Attack      = Drone is carrying out a planned attack order.

"LOOP" = Loop        = Drone is patrolling on a series of waypoints that loop on themselves.

"WYPT" = Waypoint    = Drone is flying toward a single waypoint or on a series of waypoints that do NOT loop on themselves.

"FREE" = Freeflight  = Plane has no waypoints or orders, and is in free flight, flying straight ahead.

"HOVR" = Hovering    = Helicopter has no waypoints or orders, and is hovering stationary.


_**2.) The name tab lists the type name of a drone, these are the same 3 letter abbreviations you can see from vehicle HUDs.**_
The color of the name also indicates if the health status or fuel status of the drone is in a warning or critical state, yellow is warning, red is critical.
It will automatically change to whatever of those two is in worse condition.
For example if the fuel is critical and the health is good, the name will be red, and if the fuel is good and the health is in warning, it will be yellow.

_**3.) The fuel tab lists the remaining fuel percentage of a drone as a number.**_
The percentage will also change color to indicate the fuel status:
    Between 50% and 99% the number will be white to indicate a good condition.
    Between 25% and 50% the number will be yellow to indicate a warning condition.
    Less than 25% the number will be red to indicate a critical condition.
    At full 100% fuel it will show a dark green "OK" to indicate a good launch condition.

_**4.) If the drone is damaged, the health tab lists the remaining health percentage of a drone as a number.**_
The percentage will also change color to indicate the health status:
    At full 100% health it will give no number to indicate an undamaged and good condition, and to make it easier to spot other drones that are damaged.
    Between 50% and 99% the number will be yellow to indicate a warning condition.
    Less than 50% the number will be red to indicate a critical condition.

_**5.) The last tab is the remote control status.**_
It will show a remote control symbol if a human player is viewing any of the drone's cameras, weapons or attachments from the drone control terminals.
This will show even if the drone and its attachments are still fully in automatic mode, so check the status tab if you want to check manual flight controls.

***KNOWN ISSUES:***

0.) This mod only changes the drone list on the right of the screen, the holding pattern "map" on the left of the screen is still almost fully vanilla and has some minor vanilla issues.
    Notably holding helicopters will sometimes render too early onto the screen and the icon will overlap on the text, also they sometimes don't render accurately during the landing phase.
	In the long term, it is probably wiser to just remove the vanilla holding pattern "map", because it is not accurate and you can not control the landing and holding queue priorities anyway, so beyond the nice looks it serves no purpose.

1.) Helicopters don't use the same landing procedure like planes do when they fly from their final holding spot down to the carrier runway, they skip a step, so unlike with planes the actual landing phase variable is never set by the game with helicopters.
    I worked around this by creating a check to see if the helicopter is inside a 3D area very close behind the carrier's runway and just ahead of the final helicopter holding spot, which is the normal landing slope for them.
    This works well enough almost all the time, but it can rarely happen that for few seconds a holding helicopter is shown as landing and then again as holding if it is flying directly over the carrier to its designated holding spot.
	Like everything else in this mod this is only cosmetic and has no impact on actual landing procedures.
	If this gets patched the mod should still work correctly because the mod's landing check is done anyway before the 3D area check.

***COMPABILITY AND PERMISSIONS:***

Because this mod only changes the screen code, it is entirely client-side, so you can run it even if others on a multiplayer server are not.
Future game patches and other mods might change this file, or you may want to adjust my mod to your needs, or you want to merge this mod code into your own mod, or you want to patch it for future game versions if I don't update this anymore.
In every case, you can use, copy and change the modded code as you like within the rights of MicroProse and Geometa.

***THANKS TO:***

My friends for testing the mod and being awesome in general!
All the modders (especially Quantx) who are putting in hard work to improve the game!
Geometa and Microprose for making this game!