### PR TITLE
Adding weight in kg to the tooltip for the stock bar

### DIFF
--- a/scripts/library_util.lua
+++ b/scripts/library_util.lua
@@ -38,7 +38,7 @@ vessel_names = {
 }
 
 uimod_version = {
-    game = "v1.1.3",
+    game = "v1.1.4",
     mod = "v9.1"
 }
 

--- a/scripts/screen_inventory.lua
+++ b/scripts/screen_inventory.lua
@@ -2212,7 +2212,7 @@ function render_carrier_load_graph(x, y, w, h, vehicle)
         { width=(bar_length_mult * (ordered_weight / capacity * 100)), col=color8(32, 32, 32, 255) },
     }
 
-    local hover_v = (g_pointer_pos_y >= 16 and g_pointer_pos_y < (16 + h - 3))
+    local hover_v = (g_pointer_pos_y >= 17 and g_pointer_pos_y < (17 + h - 3))
 
     local selected_bar = 0
 


### PR DESCRIPTION
Just a suggestion, seems to be interesting.

The main problem i had was although i knew i was close to full, i didn't know easily how much i could actually load on without adding things and then removing them again.

So I added the weight values to each section on the toolbar, specifically so i could so see how much free space there was in easily digestible units that i could actually use.

I also tweaked the activation region for the tooltip.