### PR TITLE
Change holomap bearing indicator to use world rather than screen coordinates

### DIFF
--- a/ui_enhancer/source/scripts/screen_holomap.lua
+++ b/ui_enhancer/source/scripts/screen_holomap.lua
@@ -719,6 +719,10 @@ function update(screen_w, screen_h, ticks)
             local bearing = 90 + angle / math.pi * 180
             if bearing < 0 then bearing = bearing + 360 end
 
+            local angle_world = math.atan(world_y - g_ruler_y, world_x - g_ruler_x)
+            local bearing_world = 90 - angle_world / math.pi * 180
+            if bearing_world < 0 then bearing_world = bearing_world + 360 end
+
             if dist_screen > 5 then
                 local function rotate(x, y, a)
                     local s = math.sin(a)
@@ -755,7 +759,7 @@ function update(screen_w, screen_h, ticks)
             end
 
             update_ui_image(cx, cy, atlas_icons.column_angle, icon_col, 0)
-            update_ui_text(cx + 15, cy, string.format("%.0f deg", bearing), 100, 0, text_col, 0)
+            update_ui_text(cx + 15, cy, string.format("%.0f deg", bearing_world), 100, 0, text_col, 0)
             cy = cy - 10
 
             local dist = vec2_dist(vec2(g_ruler_x, g_ruler_y), vec2(world_x, world_y))


### PR DESCRIPTION
Fixes an issue where the holomap bearing indicator becomes less accurate the closer it is to a diagonal angle.

This seems to be caused by the screen coordinate system being ~15% wider than it is tall, causing the ruler to give incorrect readings the further it strays from the cardinal directions. In the screenshots below I've drawn the line between two corners of a 1km grid square, which should give a perfect reading of 45 degrees.

Original, bearing based on screen coordinates:
![bearing-original](https://user-images.githubusercontent.com/4944185/187052155-455e0c67-ee08-4a1f-ba4c-d14398356260.jpg)

Fixed, bearing based on world coordinates:
![bearing-fixed](https://user-images.githubusercontent.com/4944185/187052157-1358b156-c5fb-4d77-99bc-f38f85c44e85.jpg)

Should be noted that this issue also appears to affect the vanilla game, though I gather there's some work in progress to officially integrate the mod? Either way, happy to also open a ticket on Geometa issue tracker if you think it's worthwhile.