### PR TITLE
Corrected vehicle loadout display

### DIFF
--- a/ui_enhancer/source/scripts/screen_vehicle_loadout.lua
+++ b/ui_enhancer/source/scripts/screen_vehicle_loadout.lua
@@ -38,7 +38,7 @@ function get_selected_chassis_options(bay_index)
             { region=atlas_icons.icon_chassis_16_wing_small, type=e_game_object_type.chassis_air_wing_light },
             { region=atlas_icons.icon_chassis_16_wing_large, type=e_game_object_type.chassis_air_wing_heavy },
             { region=atlas_icons.icon_chassis_16_rotor_small, type=e_game_object_type.chassis_air_rotor_light },
-            { region=atlas_icons.icon_chassis_16_rotor_large, type=e_game_object_type.chassis_air_rotor_large }
+            { region=atlas_icons.icon_chassis_16_rotor_large, type=e_game_object_type.chassis_air_rotor_heavy }
         }
     end
 

--- a/ui_enhancer/source/scripts/screen_vehicle_loadout.lua
+++ b/ui_enhancer/source/scripts/screen_vehicle_loadout.lua
@@ -29,7 +29,8 @@ function get_selected_chassis_options(bay_index)
             { region=atlas_icons.icon_attachment_16_none, type=-1 },
             { region=atlas_icons.icon_chassis_16_wheel_small, type=e_game_object_type.chassis_land_wheel_light },
             { region=atlas_icons.icon_chassis_16_wheel_medium, type=e_game_object_type.chassis_land_wheel_medium },
-            { region=atlas_icons.icon_chassis_16_wheel_large, type=e_game_object_type.chassis_land_wheel_heavy }
+            { region=atlas_icons.icon_chassis_16_wheel_large, type=e_game_object_type.chassis_land_wheel_heavy },
+            { region=atlas_icons.icon_chassis_16_wheel_mule, type=e_game_object_type.chassis_land_wheel_mule }
         }
     else
         return {
@@ -37,8 +38,7 @@ function get_selected_chassis_options(bay_index)
             { region=atlas_icons.icon_chassis_16_wing_small, type=e_game_object_type.chassis_air_wing_light },
             { region=atlas_icons.icon_chassis_16_wing_large, type=e_game_object_type.chassis_air_wing_heavy },
             { region=atlas_icons.icon_chassis_16_rotor_small, type=e_game_object_type.chassis_air_rotor_light },
-            { region=atlas_icons.icon_chassis_16_wheel_large, type=e_game_object_type.chassis_land_wheel_heavy },
-            { region=atlas_icons.icon_chassis_16_wheel_mule, type=e_game_object_type.chassis_land_wheel_mule }
+            { region=atlas_icons.icon_chassis_16_rotor_large, type=e_game_object_type.chassis_air_rotor_large }
         }
     end
 


### PR DESCRIPTION
Currently:

- heavy and mule show in the air section of the loadout display
- The heavy shows up in both air and land section
 
This change corrects this for the new update