### PR TITLE
Optimise Loop Check (landing screen)

### DIFF
--- a/ui_enhancer/source/scripts/screen_landing.lua
+++ b/ui_enhancer/source/scripts/screen_landing.lua
@@ -413,17 +413,12 @@ function render_vehicle_list( win_list, is_air )
                     vehicle_state_description = "Waiting for Delta Go"
                     vehicle_state_color = color_status_warning
                 else
-                    --iterate through the waypoints and see if they loop on themselves
-                    for w = 0, waypoint_count - 1, 1 do
-                        waypoint = vehicle:get_waypoint(w)
-                        
-                        if waypoint:get_repeat_index(w) >= 0 then
+                    --Check last waypoint to see if it loops back
+                        if waypoint:get_repeat_index(waypoint_count - 1) >= 0 then
                             vehicle_state_string = "LOOP"
                             vehicle_state_description = "Following Waypoint Loop"
                             vehicle_state_color = color8(0, 30, 230, 255)
-                            break
                         end
-                    end
                 end
             
             -- free and hover modes

--- a/ui_enhancer/source/scripts/screen_landing.lua
+++ b/ui_enhancer/source/scripts/screen_landing.lua
@@ -413,12 +413,14 @@ function render_vehicle_list( win_list, is_air )
                     vehicle_state_description = "Waiting for Delta Go"
                     vehicle_state_color = color_status_warning
                 else
-                    --Check last waypoint to see if it loops back
-                        if waypoint:get_repeat_index(waypoint_count - 1) >= 0 then
-                            vehicle_state_string = "LOOP"
-                            vehicle_state_description = "Following Waypoint Loop"
-                            vehicle_state_color = color8(0, 30, 230, 255)
-                        end
+                    --check last waypoint to see if it repeats									
+					-- if waypoints loop (i.e. not -1), and the aircraft is currently looping (>0 indicates on route to looping path) then show as looping
+					if vehicle:get_waypoint(waypoint_count - 1):get_repeat_index() == 0 then
+						vehicle_state_string = "LOOP"
+                        vehicle_state_description = "Following Waypoint Loop"
+                        vehicle_state_color = color8(0, 30, 230, 255)
+						
+                    end
                 end
             
             -- free and hover modes


### PR DESCRIPTION
Removes iteration over waypoints to determine whether they loop. The loop index is always stored in the last waypoint.